### PR TITLE
Issue 1 - Register package with Github

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,4 +47,11 @@
 			<version>1.0.0.RELEASE</version>
 		</dependency>
 	</dependencies>
+	<distributionManagement>
+	   <repository>
+	     <id>github</id>
+	     <name>Spring Mailgun Email Sender</name>
+	     <url>https://maven.pkg.github.com/justinmuskopf/spring_mailgun_email_sender</url>
+	   </repository>
+	</distributionManagement>
 </project>


### PR DESCRIPTION
Added distributionManagement to pom.xml

@justinmuskopf  before we automate this, you can do a manual deployment. Setup your [settings.xml](https://help.github.com/en/github/managing-packages-with-github-packages/configuring-apache-maven-for-use-with-github-packages#authenticating-to-github-packages) and then do a `mvn deploy`